### PR TITLE
[vstest/subintf] Add vs test case to validate processing sequence of APPL DB keys

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -13,4 +13,5 @@ RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb
 RUN dpkg -i /debs/syncd-vs_1.0.0_amd64.deb
 
+RUN dpkg --purge swss
 RUN dpkg -i /debs/swss_1.0.0_amd64.deb

--- a/fdbsyncd/fdbsync.cpp
+++ b/fdbsyncd/fdbsync.cpp
@@ -43,6 +43,36 @@ FdbSync::~FdbSync()
     }
 }
 
+
+// Check if interface entries are restored in kernel
+bool FdbSync::isIntfRestoreDone()
+{
+    vector<string> required_modules = {
+            "vxlanmgrd",
+            "intfmgrd",
+            "vlanmgrd",
+            "vrfmgrd"
+        };
+
+    for (string& module : required_modules)
+    {
+        WarmStart::WarmStartState state;
+        
+        WarmStart::getWarmStartState(module, state);
+        if (state == WarmStart::REPLAYED || state == WarmStart::RECONCILED)
+        {
+            SWSS_LOG_INFO("Module %s Replayed or Reconciled %d",module.c_str(), (int) state);            
+        }
+        else
+        {
+            SWSS_LOG_INFO("Module %s NOT Replayed or Reconciled %d",module.c_str(), (int) state);            
+            return false;
+        }
+    }
+    
+    return true;
+}
+
 void FdbSync::processCfgEvpnNvo()
 {
     std::deque<KeyOpFieldsValuesTuple> entries;
@@ -447,6 +477,10 @@ void FdbSync::macDelVxlanDB(string key)
     fvVector.push_back(t);
     fvVector.push_back(v);
 
+    SWSS_LOG_NOTICE("%sVXLAN_FDB_TABLE: DEL_KEY %s vtep:%s type:%s", 
+            m_AppRestartAssist->isWarmStartInProgress() ? "WARM-RESTART:" : "" ,
+            key.c_str(), vtep.c_str(), type.c_str());
+
     // If warmstart is in progress, we take all netlink changes into the cache map
     if (m_AppRestartAssist->isWarmStartInProgress())
     {
@@ -454,7 +488,6 @@ void FdbSync::macDelVxlanDB(string key)
         return;
     }
     
-    SWSS_LOG_INFO("VXLAN_FDB_TABLE: DEL_KEY %s vtep:%s type:%s", key.c_str(), vtep.c_str(), type.c_str());
     m_fdbTable.del(key);
     return;
 
@@ -476,6 +509,9 @@ void FdbSync::macAddVxlan(string key, struct in_addr vtep, string type, uint32_t
     fvVector.push_back(t);
     fvVector.push_back(v);
 
+    SWSS_LOG_INFO("%sVXLAN_FDB_TABLE: ADD_KEY %s vtep:%s type:%s", 
+            m_AppRestartAssist->isWarmStartInProgress() ? "WARM-RESTART:" : "" ,
+            key.c_str(), svtep.c_str(), type.c_str());
     // If warmstart is in progress, we take all netlink changes into the cache map
     if (m_AppRestartAssist->isWarmStartInProgress())
     {
@@ -483,7 +519,6 @@ void FdbSync::macAddVxlan(string key, struct in_addr vtep, string type, uint32_t
         return;
     }
     
-    SWSS_LOG_INFO("VXLAN_FDB_TABLE: ADD_KEY %s vtep:%s type:%s", key.c_str(), svtep.c_str(), type.c_str());
     m_fdbTable.set(key, fvVector);
 
     return;

--- a/fdbsyncd/fdbsync.h
+++ b/fdbsyncd/fdbsync.h
@@ -9,8 +9,17 @@
 #include "netmsg.h"
 #include "warmRestartAssist.h"
 
-// The timeout value (in seconds) for fdbsyncd reconcilation logic
-#define DEFAULT_FDBSYNC_WARMSTART_TIMER 30
+/*
+ * Default timer interval for fdbsyncd reconcillation 
+ */
+#define DEFAULT_FDBSYNC_WARMSTART_TIMER 120
+
+/*
+ * This is the MAX time in seconds, fdbsyncd will wait after warm-reboot
+ * for the interface entries to be recreated in kernel before attempting to 
+ * write the FDB data to kernel
+ */
+#define INTF_RESTORE_MAX_WAIT_TIME 180
 
 namespace swss {
 
@@ -43,7 +52,7 @@ public:
 
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
-    bool isFdbRestoreDone();
+    bool isIntfRestoreDone();
 
     AppRestartAssist *getRestartAssist()
     {

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -18,6 +18,7 @@ using namespace swss;
  */
 const uint32_t DEFAULT_ROUTING_RESTART_INTERVAL = 120;
 
+
 // Wait 3 seconds after detecting EOIU reached state
 // TODO: support eoiu hold interval config
 const uint32_t DEFAULT_EOIU_HOLD_INTERVAL = 3;
@@ -67,6 +68,7 @@ int main(int argc, char **argv)
             SelectableTimer eoiuCheckTimer(timespec{0, 0});
             // After eoiu flags are detected, start a hold timer before starting reconciliation.
             SelectableTimer eoiuHoldTimer(timespec{0, 0});
+           
             /*
              * Pipeline should be flushed right away to deal with state pending
              * from previous try/catch iterations.
@@ -108,6 +110,10 @@ int main(int argc, char **argv)
                 s.addSelectable(&eoiuCheckTimer);
                 SWSS_LOG_NOTICE("Warm-Restart eoiuCheckTimer timer started.");
             }
+            else
+            {
+                sync.m_warmStartHelper.setState(WarmStart::WSDISABLED);
+            }
 
             while (true)
             {
@@ -132,6 +138,7 @@ int main(int argc, char **argv)
                     {
                         SWSS_LOG_NOTICE("Warm-Restart EOIU hold timer expired.");
                     }
+
                     if (sync.m_warmStartHelper.inProgress())
                     {
                         sync.m_warmStartHelper.reconcile();

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -588,8 +588,8 @@ void IntfsOrch::doTask(Consumer &consumer)
         string vrf_name = "", vnet_name = "", nat_zone = "";
         MacAddress mac;
 
-        uint32_t mtu;
-        bool adminUp;
+        uint32_t mtu = 0;
+        bool adminUp = false;
         uint32_t nat_zone_id = 0;
         string proxy_arp = "";
         string inband_type = "";
@@ -742,7 +742,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             Port port;
             if (!gPortsOrch->getPort(alias, port))
             {
-                if (isSubIntf)
+                if (!ip_prefix_in_key && isSubIntf)
                 {
                     if (!gPortsOrch->addSubPort(port, alias, adminUp, mtu))
                     {

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -742,7 +742,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             Port port;
             if (!gPortsOrch->getPort(alias, port))
             {
-                if (isSubIntf)
+                if (isSubIntf && !ip_prefix_in_key)
                 {
                     if (!gPortsOrch->addSubPort(port, alias, adminUp, mtu))
                     {

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -742,7 +742,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             Port port;
             if (!gPortsOrch->getPort(alias, port))
             {
-                if (isSubIntf && !ip_prefix_in_key)
+                if (isSubIntf)
                 {
                     if (!gPortsOrch->addSubPort(port, alias, adminUp, mtu))
                     {

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -87,6 +87,7 @@ public:
     void setState(string state);
     string getState();
     bool isStateChangeInProgress() { return st_chg_in_progress_; }
+    bool isStateChangeFailed() { return st_chg_failed_; }
 
     bool isIpInSubnet(IpAddress ip);
     void updateNeighbor(NextHopKey nh, bool add);
@@ -107,6 +108,7 @@ private:
 
     MuxState state_ = MuxState::MUX_STATE_INIT;
     bool st_chg_in_progress_ = false;
+    bool st_chg_failed_ = false;
 
     IpPrefix srv_ip4_, srv_ip6_;
     IpAddress peer_ip4_;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2228,7 +2228,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 /* Set autoneg and ignore the port speed setting */
                 else if (fvField(i) == "autoneg")
                 {
-                    an = (int)stoul(fvValue(i));
+                    an = (fvValue(i) == "on");
                 }
                 /* Set port serdes Pre-emphasis */
                 else if (fvField(i) == "preemphasis")

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -174,7 +174,7 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
     unsigned int flags = rtnl_link_get_flags(link);
     bool admin = flags & IFF_UP;
-    bool oper = flags & IFF_LOWER_UP;
+    bool oper = flags & IFF_RUNNING;
 
     char addrStr[MAX_ADDR_SIZE+1] = {0};
     nl_addr2str(rtnl_link_get_addr(link), addrStr, MAX_ADDR_SIZE);

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -12,8 +12,8 @@ class TestPortAutoNeg(object):
 
         tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
 
-        # set autoneg = false and speed = 1000
-        fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
+        # set autoneg = true and speed = 1000
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"), ("speed", "1000")])
 
         tbl.set("Ethernet0", fvs)
 
@@ -50,7 +50,7 @@ class TestPortAutoNeg(object):
                 assert fv[1] == "1:100"
 
         # change autoneg to false
-        fvs = swsscommon.FieldValuePairs([("autoneg","0")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","off")])
 
         tbl.set("Ethernet0", fvs)
 
@@ -99,7 +99,7 @@ class TestPortAutoNeg(object):
         stbl = swsscommon.Table(sdb, "PORT_TABLE")
 
         # set autoneg = true and speed = 1000
-        fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"), ("speed", "1000")])
         ctbl.set("Ethernet0", fvs)
 
         time.sleep(1)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -34,6 +34,7 @@ ETHERNET_PREFIX = "Ethernet"
 LAG_PREFIX = "PortChannel"
 
 VLAN_SUB_INTERFACE_SEPARATOR = "."
+APPL_DB_SEPARATOR = ":"
 
 
 class TestSubPortIntf(object):
@@ -102,13 +103,11 @@ class TestSubPortIntf(object):
             key = "{}|{}".format(lag, member)
             self.config_db.create_entry(CFG_LAG_MEMBER_TABLE_NAME, key, fvs)
 
-    def create_sub_port_intf_profile_appl_db(self, sub_port_intf_name, admin_status, vrf_name=""):
+    def create_sub_port_intf_profile_appl_db(self, sub_port_intf_name, admin_status):
         pairs = [
             (ADMIN_STATUS, admin_status),
             ("mtu", "0"),
         ]
-        if vrf_name:
-            pairs.append((VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME, vrf_name))
         fvs = swsscommon.FieldValuePairs(pairs)
 
         tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
@@ -350,28 +349,22 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_add_ip_addrs(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_add_ip_addrs(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
-
-    def _test_sub_port_intf_appl_db_proc_seq(self, dvs, sub_port_intf_name, admin_up, vrf_name=None):
+    def _test_sub_port_intf_appl_db_proc_seq(self, dvs, sub_port_intf_name, admin_up):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
         parent_port = substrs[0]
         vlan_id = substrs[1]
 
-        vrf_oid = self.default_vrf_oid
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
 
         self.set_parent_port_admin_status(dvs, parent_port, "up")
-        if vrf_name:
-            self.create_vrf(vrf_name)
-            vrf_oid = self.get_newly_created_oid(ASIC_VIRTUAL_ROUTER_TABLE, [vrf_oid])
 
         # Create ip address configuration in APPL_DB before creating configuration for sub port interface itself
         self.add_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
-        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
-            self.add_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
         time.sleep(2)
 
         # Create sub port interface configuration in APPL_DB
-        self.create_sub_port_intf_profile_appl_db(sub_port_intf_name, "up" if admin_up == True else "down", vrf_name)
+        self.create_sub_port_intf_profile_appl_db(sub_port_intf_name, "up" if admin_up == True else "down")
 
         # Verify that a sub port router interface entry is created in ASIC_DB
         fv_dict = {
@@ -380,26 +373,16 @@ class TestSubPortIntf(object):
             "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true" if admin_up == True else "false",
             "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true" if admin_up == True else "false",
             "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
-            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
         }
         rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
         # Remove ip addresses from APPL_DB
         self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
-        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
-            self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
         # Remove sub port interface from APPL_DB
         self.remove_sub_port_intf_profile_appl_db(sub_port_intf_name)
         self.check_sub_port_intf_profile_removal(rif_oid)
-
-        # Remove vrf if created
-        if vrf_name:
-            self.remove_vrf(vrf_name)
-            self.check_vrf_removal(vrf_oid)
-            if vrf_name.startswith(VNET_PREFIX):
-                self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
-                self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
 
     def test_sub_port_intf_appl_db_proc_seq(self, dvs):
         self.connect_dbs(dvs)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -111,7 +111,7 @@ class TestSubPortIntf(object):
             pairs.append((VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME, vrf_name))
         fvs = swsscommon.FieldValuePairs(pairs)
 
-        tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
+        tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
         tbl.set(sub_port_intf_name, fvs)
 
     def add_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
@@ -127,7 +127,7 @@ class TestSubPortIntf(object):
         ]
         fvs = swsscommon.FieldValuePairs(pairs)
 
-        tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
+        tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
         tbl.set(sub_port_intf_name + APPL_DB_SEPARATOR + ip_addr, fvs)
 
     def set_sub_port_intf_admin_status(self, sub_port_intf_name, status):
@@ -147,7 +147,7 @@ class TestSubPortIntf(object):
         self.asic_db.wait_for_deleted_keys(ASIC_RIF_TABLE, [rif_oid])
 
     def remove_sub_port_intf_profile_appl_db(self, sub_port_intf_name):
-        tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
+        tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
         tbl._del(sub_port_intf_name)
 
     def remove_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
@@ -159,7 +159,7 @@ class TestSubPortIntf(object):
         self.app_db.wait_for_deleted_keys(APP_INTF_TABLE_NAME, interfaces)
 
     def remove_sub_port_intf_ip_addr_appl_db(self, sub_port_intf_name, ip_addr):
-        tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
+        tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
         tbl._del(sub_port_intf_name + APPL_DB_SEPARATOR + ip_addr)
 
     def get_oids(self, table):

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -350,7 +350,8 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_add_ip_addrs(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_add_ip_addrs(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
-    def _test_sub_port_intf_appl_db_proc_order(self, dvs, sub_port_intf_name, admin_up, vrf_name=None):
+
+    def _test_sub_port_intf_appl_db_proc_seq(self, dvs, sub_port_intf_name, admin_up, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
         parent_port = substrs[0]
         vlan_id = substrs[1]
@@ -400,14 +401,14 @@ class TestSubPortIntf(object):
                 self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
                 self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
 
-    def test_sub_port_intf_appl_db_proc_order(self, dvs):
+    def test_sub_port_intf_appl_db_proc_seq(self, dvs):
         self.connect_dbs(dvs)
 
-        self._test_sub_port_intf_appl_db_proc_order(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
-        self._test_sub_port_intf_appl_db_proc_order(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)
+        self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
+        self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)
 
-        self._test_sub_port_intf_appl_db_proc_order(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
-        self._test_sub_port_intf_appl_db_proc_order(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)
+        self._test_sub_port_intf_appl_db_proc_seq(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
+        self._test_sub_port_intf_appl_db_proc_seq(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)
 
     def _test_sub_port_intf_admin_status_change(self, dvs, sub_port_intf_name):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -114,8 +114,6 @@ class TestSubPortIntf(object):
         tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
         tbl.set(sub_port_intf_name, fvs)
 
-        time.sleep(1)
-
     def add_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
         fvs = {"NULL": "NULL"}
 
@@ -131,8 +129,6 @@ class TestSubPortIntf(object):
 
         tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
         tbl.set(sub_port_intf_name + APPL_DB_SEPARATOR + ip_addr, fvs)
-
-        time.sleep(2)
 
     def set_sub_port_intf_admin_status(self, sub_port_intf_name, status):
         fvs = {ADMIN_STATUS: status}
@@ -154,8 +150,6 @@ class TestSubPortIntf(object):
         tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
         tbl._del(sub_port_intf_name)
 
-        time.sleep(1)
-
     def remove_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
         key = "{}|{}".format(sub_port_intf_name, ip_addr)
         self.config_db.delete_entry(CFG_VLAN_SUB_INTF_TABLE_NAME, key)
@@ -167,8 +161,6 @@ class TestSubPortIntf(object):
     def remove_sub_port_intf_ip_addr_appl_db(self, sub_port_intf_name, ip_addr):
         tbl = swsscommon.ProducerStateTable(self.appl_db, APP_INTF_TABLE_NAME)
         tbl._del(sub_port_intf_name + APPL_DB_SEPARATOR + ip_addr)
-
-        time.sleep(1)
 
     def get_oids(self, table):
         return self.asic_db.get_keys(table)
@@ -358,7 +350,7 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_add_ip_addrs(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_add_ip_addrs(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
-    def _test_sub_port_intf_appl_db_proc_order(self, dvs, sub_port_intf_name, admin_up, vrf_name=""):
+    def _test_sub_port_intf_appl_db_proc_order(self, dvs, sub_port_intf_name, admin_up, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
         parent_port = substrs[0]
         vlan_id = substrs[1]
@@ -371,10 +363,11 @@ class TestSubPortIntf(object):
             self.create_vrf(vrf_name)
             vrf_oid = self.get_newly_created_oid(ASIC_VIRTUAL_ROUTER_TABLE, [vrf_oid])
 
-        # Create IP address configuration in APPL_DB before creating configuration for sub port interface itself
+        # Create ip address configuration in APPL_DB before creating configuration for sub port interface itself
         self.add_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
-        if not vrf_name.startswith(VNET_PREFIX):
+        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
             self.add_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+        time.sleep(2)
 
         # Create sub port interface configuration in APPL_DB
         self.create_sub_port_intf_profile_appl_db(sub_port_intf_name, "up" if admin_up == True else "down", vrf_name)
@@ -391,16 +384,21 @@ class TestSubPortIntf(object):
         rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
-        # Remove IP addresses from APPL_DB
+        # Remove ip addresses from APPL_DB
         self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
-        if not vrf_name.startswith(VNET_PREFIX):
+        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
             self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
         # Remove sub port interface from APPL_DB
         self.remove_sub_port_intf_profile_appl_db(sub_port_intf_name)
+        self.check_sub_port_intf_profile_removal(rif_oid)
 
         # Remove vrf if created
         if vrf_name:
             self.remove_vrf(vrf_name)
+            self.check_vrf_removal(vrf_oid)
+            if vrf_name.startswith(VNET_PREFIX):
+                self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
+                self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
 
     def test_sub_port_intf_appl_db_proc_order(self, dvs):
         self.connect_dbs(dvs)

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -76,7 +76,7 @@ def swss_app_check_RestoreCount_single(state_db, restore_count, name):
             if fv[0] == "restore_count":
                 assert int(fv[1]) == restore_count[key] + 1
             elif fv[0] == "state":
-                assert fv[1] == "reconciled"  or fv[1] == "disabled"
+                assert fv[1] == "reconciled" or fv[1] == "disabled"
 
 def swss_app_check_warmstart_state(state_db, name, state):
     warmtbl = swsscommon.Table(state_db, swsscommon.STATE_WARM_RESTART_TABLE_NAME)
@@ -1150,7 +1150,7 @@ class TestWarmReboot(object):
         time.sleep(5)
 
         # Verify FSM
-        swss_app_check_warmstart_state(state_db, "bgp", "")
+        swss_app_check_warmstart_state(state_db, "bgp", "disabled")
 
         # Verify that multiple changes are seen in swss and sairedis logs as there's
         # no warm-reboot logic in place.

--- a/warmrestart/warmRestartAssist.cpp
+++ b/warmrestart/warmRestartAssist.cpp
@@ -117,6 +117,16 @@ AppRestartAssist::cache_state_t AppRestartAssist::getCacheEntryState(const std::
     throw std::logic_error("cache entry state is invalid");
 }
 
+void AppRestartAssist::appDataReplayed()
+{
+    WarmStart::setWarmStartState(m_appName, WarmStart::REPLAYED);
+}
+
+void AppRestartAssist::warmStartDisabled()
+{
+    WarmStart::setWarmStartState(m_appName, WarmStart::WSDISABLED);
+}
+
 // Read table(s) from APPDB and append stale flag then insert to cachemap
 void AppRestartAssist::readTablesToMap()
 {
@@ -272,6 +282,13 @@ void AppRestartAssist::reconcile()
     WarmStart::setWarmStartState(m_appName, WarmStart::RECONCILED);
     m_warmStartInProgress = false;
     return;
+}
+
+// set the reconcile interval
+void AppRestartAssist::setReconcileInterval(uint32_t time)
+{
+    m_reconcileTimer = time;
+    m_warmStartTimer.setInterval(timespec{m_reconcileTimer, 0});
 }
 
 // start the timer, take Select class "s" to add the timer.

--- a/warmrestart/warmRestartAssist.h
+++ b/warmrestart/warmRestartAssist.h
@@ -75,10 +75,13 @@ public:
         DELETE  = 3
     };
     // These functions were used as described in the class description
+    void setReconcileInterval(uint32_t time);
     void startReconcileTimer(Select &s);
     void stopReconcileTimer(Select &s);
     bool checkReconcileTimer(Selectable *s);
     void readTablesToMap(void);
+    void appDataReplayed(void);
+    void warmStartDisabled(void);
     void insertToMap(std::string tableName, std::string key, std::vector<FieldValueTuple> fvVector, bool delete_key);
     void reconcile(void);
     bool isWarmStartInProgress(void)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Crafted a vs test case to validate the processing sequence of `VLAN_SUB_INTERFACE` keys---Key without ip prefix must be processed prior to those with ip prefix when Port object representing sub port interface has not yet been created. If not this case, user configuration other than `vrf_name` in CONFIG_DB, such as `admin_status`, will be ignored in later creating SAI sub port interface, a symptom observed in . 

**Why I did it**
Fix in should pass the vs test case added here.

**How I verified it**
vs test on `test_sub_port_intf_appl_db_proc_seq` fails without a fix.

#### Physical parent port
##### `admin_status` being configured `up`
```
=========================================================================== FAILURES ===========================================================================
_____________________________________________________ TestSubPortIntf.test_sub_port_intf_appl_db_proc_seq ______________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7efc29be75c0>, dvs = <conftest.DockerVirtualSwitch object at 0x7efc29bcfcc0>

    def test_sub_port_intf_appl_db_proc_seq(self, dvs):
        self.connect_dbs(dvs)
    
>       self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)

test_sub_port_intf.py:390: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test_sub_port_intf.py:378: in _test_sub_port_intf_appl_db_proc_seq
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
test_sub_port_intf.py:199: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <dvslib.dvs_database.DVSDatabase object at 0x7efc29b15be0>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE', key = 'oid:0x60000000005f6'
expected_fields = {'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', ...}
polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True), failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100'}, received={'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID': 'oid:0x3000000000022', 'SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS': '02:42:AC:11:00:02', 'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_PORT_ID': 'oid:0x1000000000012', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '32582', 'SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID': '0'}, key="oid:0x60000000005f6", table="ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"

dvslib/dvs_database.py:203: AssertionError
=================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_appl_db_proc_seq - AssertionError: Expected field/value pairs not found: expected={'SAI_ROU...
================================================================= 1 failed in 68.88s (0:01:08) =================================================================
```

##### `admin_status` being configured `down`
```
=========================================================================== FAILURES ===========================================================================
_____________________________________________________ TestSubPortIntf.test_sub_port_intf_appl_db_proc_seq ______________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7fc5bfada208>, dvs = <conftest.DockerVirtualSwitch object at 0x7fc5bfad6278>

    def test_sub_port_intf_appl_db_proc_seq(self, dvs):
        self.connect_dbs(dvs)
    
        #self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
>       self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)

test_sub_port_intf.py:391: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test_sub_port_intf.py:378: in _test_sub_port_intf_appl_db_proc_seq
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
test_sub_port_intf.py:199: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <dvslib.dvs_database.DVSDatabase object at 0x7fc5bfab92e8>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE', key = 'oid:0x60000000005f6'
expected_fields = {'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', ...}
polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True), failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100'}, received={'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID': 'oid:0x3000000000022', 'SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS': '02:42:AC:11:00:02', 'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_PORT_ID': 'oid:0x1000000000012', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '32531', 'SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID': '0'}, key="oid:0x60000000005f6", table="ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"

dvslib/dvs_database.py:203: AssertionError
=================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_appl_db_proc_seq - AssertionError: Expected field/value pairs not found: expected={'SAI_ROU...
================================================================= 1 failed in 69.14s (0:01:09) =================================================================
```

#### Lag parent port
##### `admin_status` being configured `up`
```
=========================================================================== FAILURES ===========================================================================
_____________________________________________________ TestSubPortIntf.test_sub_port_intf_appl_db_proc_seq ______________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f7b769c6d30>, dvs = <conftest.DockerVirtualSwitch object at 0x7f7b76a60b70>

    def test_sub_port_intf_appl_db_proc_seq(self, dvs):
        self.connect_dbs(dvs)
    
        #self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
        #self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)
    
>       self._test_sub_port_intf_appl_db_proc_seq(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)

test_sub_port_intf.py:393: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test_sub_port_intf.py:378: in _test_sub_port_intf_appl_db_proc_seq
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
test_sub_port_intf.py:199: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <dvslib.dvs_database.DVSDatabase object at 0x7f7b769a4d68>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE', key = 'oid:0x60000000005f7'
expected_fields = {'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '20', ...}
polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True), failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '20', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100'}, received={'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID': 'oid:0x3000000000022', 'SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS': '02:42:AC:11:00:02', 'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_PORT_ID': 'oid:0x20000000005f6', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '20', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '32553', 'SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID': '0'}, key="oid:0x60000000005f7", table="ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"

dvslib/dvs_database.py:203: AssertionError
=================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_appl_db_proc_seq - AssertionError: Expected field/value pairs not found: expected={'SAI_ROU...
================================================================= 1 failed in 67.17s (0:01:07) =================================================================
```

##### `admin_status` being configured `down`
```
=========================================================================== FAILURES ===========================================================================
_____________________________________________________ TestSubPortIntf.test_sub_port_intf_appl_db_proc_seq ______________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f4ce1824080>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4ce18bf828>

    def test_sub_port_intf_appl_db_proc_seq(self, dvs):
        self.connect_dbs(dvs)
    
        #self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
        #self._test_sub_port_intf_appl_db_proc_seq(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)
    
        #self._test_sub_port_intf_appl_db_proc_seq(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=True)
>       self._test_sub_port_intf_appl_db_proc_seq(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, admin_up=False)

test_sub_port_intf.py:394: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
test_sub_port_intf.py:378: in _test_sub_port_intf_appl_db_proc_seq
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
test_sub_port_intf.py:199: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <dvslib.dvs_database.DVSDatabase object at 0x7f4ce1804b38>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE', key = 'oid:0x60000000005f7'
expected_fields = {'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '20', ...}
polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True), failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '20', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'false', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100'}, received={'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID': 'oid:0x3000000000022', 'SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS': '02:42:AC:11:00:02', 'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_PORT_ID': 'oid:0x20000000005f6', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '20', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '32567', 'SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID': '0'}, key="oid:0x60000000005f7", table="ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"

dvslib/dvs_database.py:203: AssertionError
=================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_appl_db_proc_seq - AssertionError: Expected field/value pairs not found: expected={'SAI_ROU...
================================================================= 1 failed in 67.92s (0:01:07) =================================================================
```

**Details if related**

1.  Set `VLAN_SUB_INTERFACE` keys with ip prefix into `APPL_DB`
2.  Allow enough time for IntfsOrch to look into keys with ip prefix (sleep 2 seconds)
3. Set `VLAN_SUB_INTERFACE` key without ip prefix into `APPL_DB`
4. Iterate test run on all possible `admin_staus` values, i.e., `up` and `down`, to make sure ASIC_DB sub interface attribute `ADMIN_V4_STATE` and `ADMIN_V6_STATE` are set according to user configuration, rather than being agnostic to user configuration as a result of  Port object being created by keys with ip prefix.
