### PR TITLE
[subintf] Mirror via a local sub port router interface

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1360,11 +1360,21 @@ void MirrorOrch::updateLagMember(const LagMemberUpdate& update)
             }
         }
 
+        Port p = session.neighborInfo.port;
+        if (p.m_type == Port::SUBPORT)
+        {
+            if (!m_portsOrch->getPort(p.m_parent_port_id, p))
+            {
+                SWSS_LOG_ERROR("Parent lag of local sub interface %s does not exist",
+                        port.m_alias.c_str());
+                continue;
+            }
+        }
+
         // Check the following two conditions:
         // 1) the neighbor is LAG
         // 2) the neighbor LAG matches the update LAG
-        if (session.neighborInfo.port.m_type != Port::LAG ||
-                session.neighborInfo.port != update.lag)
+        if (p.m_type != Port::LAG || p != update.lag)
         {
             continue;
         }
@@ -1394,7 +1404,7 @@ void MirrorOrch::updateLagMember(const LagMemberUpdate& update)
                 {
                     deactivateSession(name, session);
                 }
-                session.neighborInfo.portId = SAI_OBJECT_TYPE_NULL;
+                session.neighborInfo.portId = SAI_NULL_OBJECT_ID;
             }
             // Switch to a new member of the LAG
             else

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -699,10 +699,20 @@ bool MirrorOrch::updateSession(const string& name, MirrorEntry& session)
         // Update corresponding attributes
         if (session.status)
         {
-            if (old_session.neighborInfo.port.m_type !=
-                    session.neighborInfo.port.m_type &&
-                (old_session.neighborInfo.port.m_type == Port::VLAN ||
-                 session.neighborInfo.port.m_type == Port::VLAN))
+            if (((old_session.neighborInfo.port.m_type == Port::VLAN
+                            || old_session.neighborInfo.port.m_type == Port::SUBPORT)
+                        && (session.neighborInfo.port.m_type != Port::VLAN
+                            && session.neighborInfo.port.m_type != Port::SUBPORT))
+                    || ((old_session.neighborInfo.port.m_type != Port::VLAN
+                            && old_session.neighborInfo.port.m_type != Port::SUBPORT)
+                        && (session.neighborInfo.port.m_type == Port::VLAN
+                            || session.neighborInfo.port.m_type == Port::SUBPORT))
+                    || (old_session.neighborInfo.port.m_type == Port::VLAN
+                        && session.neighborInfo.port.m_type == Port::SUBPORT
+                        && old_session.neighborInfo.port.m_vlan_info.vlan_id != session.neighborInfo.port.m_vlan_info.vlan_id)
+                    || (old_session.neighborInfo.port.m_type == Port::SUBPORT
+                        && session.neighborInfo.port.m_type == Port::VLAN
+                        && old_session.neighborInfo.port.m_vlan_info.vlan_id != session.neighborInfo.port.m_vlan_info.vlan_id))
             {
                 ret &= updateSessionType(name, session);
             }

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1448,7 +1448,7 @@ void MirrorOrch::updateVlanMember(const VlanMemberUpdate& update)
         }
 
         // Deactivate session. Wait for FDB event to activate session
-        session.neighborInfo.portId = SAI_OBJECT_TYPE_NULL;
+        session.neighborInfo.portId = SAI_NULL_OBJECT_ID;
         deactivateSession(name, session);
     }
 }

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -882,8 +882,9 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
         attr.value.s32 = SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE;
         attrs.push_back(attr);
 
-        // Add the VLAN header when the packet is sent out from a VLAN
-        if (session.neighborInfo.port.m_type == Port::VLAN)
+        // Add the VLAN header when the packet is sent out from a VLAN or a sub port interface
+        if (session.neighborInfo.port.m_type == Port::VLAN
+                || session.neighborInfo.port.m_type == Port::SUBPORT)
         {
             attr.id = SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID;
             attr.value.booldata = true;

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1110,7 +1110,8 @@ bool MirrorOrch::updateSessionType(const string& name, MirrorEntry& session)
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
 
-    if (session.neighborInfo.port.m_type == Port::VLAN)
+    if (session.neighborInfo.port.m_type == Port::VLAN
+            || session.neighborInfo.port.m_type == Port::SUBPORT)
     {
         attr.id = SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID;
         attr.value.booldata = true;
@@ -1147,7 +1148,7 @@ bool MirrorOrch::updateSessionType(const string& name, MirrorEntry& session)
 
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to update mirror session %s VLAN to %s, rv:%d",
+            SWSS_LOG_ERROR("Failed to update mirror session %s VLAN ID to %s, rv:%d",
                     name.c_str(), session.neighborInfo.port.m_alias.c_str(), status);
             task_process_status handle_status =  handleSaiSetStatus(SAI_API_MIRROR, status);
             if (handle_status != task_success)
@@ -1157,7 +1158,7 @@ bool MirrorOrch::updateSessionType(const string& name, MirrorEntry& session)
         }
     }
 
-    SWSS_LOG_NOTICE("Update mirror session %s VLAN to %s",
+    SWSS_LOG_NOTICE("Update mirror session %s VLAN ID to %s",
             name.c_str(), session.neighborInfo.port.m_alias.c_str());
 
     setSessionState(name, session, MIRROR_SESSION_VLAN_ID);

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -699,19 +699,20 @@ bool MirrorOrch::updateSession(const string& name, MirrorEntry& session)
         // Update corresponding attributes
         if (session.status)
         {
-            if (((old_session.neighborInfo.port.m_type == Port::VLAN
-                            || old_session.neighborInfo.port.m_type == Port::SUBPORT)
-                        && (session.neighborInfo.port.m_type != Port::VLAN
-                            && session.neighborInfo.port.m_type != Port::SUBPORT))
-                    || ((old_session.neighborInfo.port.m_type != Port::VLAN
+            // Update from non-vlan, non-subport to vlan or subport, and vice versa,
+            // Or update among vlan or subport, but to a different vlan id
+            if (((old_session.neighborInfo.port.m_type != Port::VLAN
                             && old_session.neighborInfo.port.m_type != Port::SUBPORT)
                         && (session.neighborInfo.port.m_type == Port::VLAN
                             || session.neighborInfo.port.m_type == Port::SUBPORT))
-                    || (old_session.neighborInfo.port.m_type == Port::VLAN
-                        && session.neighborInfo.port.m_type == Port::SUBPORT
-                        && old_session.neighborInfo.port.m_vlan_info.vlan_id != session.neighborInfo.port.m_vlan_info.vlan_id)
-                    || (old_session.neighborInfo.port.m_type == Port::SUBPORT
-                        && session.neighborInfo.port.m_type == Port::VLAN
+                    || ((old_session.neighborInfo.port.m_type == Port::VLAN
+                            || old_session.neighborInfo.port.m_type == Port::SUBPORT)
+                        && (session.neighborInfo.port.m_type != Port::VLAN
+                            && session.neighborInfo.port.m_type != Port::SUBPORT))
+                    || ((old_session.neighborInfo.port.m_type == Port::VLAN
+                            || old_session.neighborInfo.port.m_type == Port::SUBPORT)
+                        && (session.neighborInfo.port.m_type == Port::VLAN
+                            || session.neighborInfo.port.m_type == Port::SUBPORT)
                         && old_session.neighborInfo.port.m_vlan_info.vlan_id != session.neighborInfo.port.m_vlan_info.vlan_id))
             {
                 ret &= updateSessionType(name, session);

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1376,9 +1376,11 @@ void MirrorOrch::updateLagMember(const LagMemberUpdate& update)
             if (!m_portsOrch->getPort(p.m_parent_port_id, p))
             {
                 SWSS_LOG_ERROR("Parent lag of local sub interface %s does not exist",
-                        port.m_alias.c_str());
+                        p.m_alias.c_str());
                 continue;
             }
+
+            assert(p.m_type != Port::VLAN);
         }
 
         // Check the following two conditions:

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -600,6 +600,8 @@ bool MirrorOrch::getNeighborInfo(const string& name, MirrorEntry& session)
                     neighbor.ip_address.to_string().c_str(), neighbor.alias.c_str());
             return false;
         }
+
+        assert(p.m_type != Port::VLAN);
     }
 
     switch (p.m_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1053,12 +1053,12 @@ class DockerVirtualSwitch:
         self.runcmd("ip route change " + prefix + cmd)
         time.sleep(1)
 
-    # deps: acl, mirror_port_erspan
+    # deps: acl, mirror_port_erspan, sub port intf
     def remove_route(self, prefix):
         self.runcmd("ip route del " + prefix)
         time.sleep(1)
 
-    # deps: mirror_port_erspan
+    # deps: mirror_port_erspan, sub port intf
     def create_fdb(self, vlan, mac, interface):
         tbl = swsscommon.ProducerStateTable(self.pdb, "FDB_TABLE")
         fvs = swsscommon.FieldValuePairs([("port", interface),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -941,20 +941,20 @@ class DockerVirtualSwitch:
         tbl.set("Vlan" + vlan, fvs)
         time.sleep(1)
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def remove_vlan(self, vlan):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         tbl._del("Vlan" + vlan)
         time.sleep(1)
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def create_vlan_member(self, vlan, interface):
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
         fvs = swsscommon.FieldValuePairs([("tagging_mode", "untagged")])
         tbl.set("Vlan" + vlan + "|" + interface, fvs)
         time.sleep(1)
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def remove_vlan_member(self, vlan, interface):
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
         tbl._del("Vlan" + vlan + "|" + interface)
@@ -967,7 +967,7 @@ class DockerVirtualSwitch:
         tbl.set("Vlan" + vlan + "|" + interface, fvs)
         time.sleep(1)
 
-    # deps: fdb_update, fdb, mirror_port_erspan, mirror_port_span, vlan
+    # deps: fdb_update, fdb, mirror_port_erspan, mirror_port_span, vlan, sub port intf
     def set_interface_status(self, interface, admin_status):
         if interface.startswith("PortChannel"):
             tbl_name = "PORTCHANNEL"
@@ -980,7 +980,7 @@ class DockerVirtualSwitch:
         tbl.set(interface, fvs)
         time.sleep(1)
 
-    # deps: acl, fdb_update, fdb, mirror_port_erspan, vlan
+    # deps: acl, fdb_update, fdb, mirror_port_erspan, vlan, sub port intf
     def add_ip_address(self, interface, ip):
         if interface.startswith("PortChannel"):
             tbl_name = "PORTCHANNEL_INTERFACE"
@@ -994,7 +994,7 @@ class DockerVirtualSwitch:
         tbl.set(interface + "|" + ip, fvs)
         time.sleep(1)
 
-    # deps: acl, fdb_update, fdb, mirror_port_erspan, vlan
+    # deps: acl, fdb_update, fdb, mirror_port_erspan, vlan, sub port intf
     def remove_ip_address(self, interface, ip):
         if interface.startswith("PortChannel"):
             tbl_name = "PORTCHANNEL_INTERFACE"

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -79,7 +79,8 @@ class DVSMirror(object):
             entry = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_POLICER", policer_oid)
             assert entry["SAI_POLICER_ATTR_CIR"] == cir
             
-    def verify_session(self, dvs, name, asic_db=None, state_db=None, dst_oid=None, src_ports=None, direction="BOTH", policer=None, expected = 1, asic_size=None):
+    def verify_session(self, dvs, name, asic_db=None, state_db=None, dst_oid=None,
+                       src_ports=None, direction="BOTH", policer=None, expected=1, asic_size=None):
         member_ids = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", expected)
         session_oid=member_ids[0]
         # with multiple sessions, match on dst_oid to get session_oid

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -30,7 +30,6 @@ class DVSMirror(object):
             "dscp": dscp,
             "ttl": ttl,
             "queue": queue,
-            "direction": direction
         }
 
         if policer:
@@ -38,6 +37,9 @@ class DVSMirror(object):
 
         if src_ports:
             mirror_entry["src_port"] = src_ports
+
+            if direction:
+                mirror_entry["direction"] = direction
 
         self.config_db.create_entry("MIRROR_SESSION", name, mirror_entry)
 

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -970,7 +970,6 @@ class TestMirror(object):
         LAG_UNDER_TEST = "PortChannel" + LAG_INDEX_UNDER_TEST
         LAG_MEMBER_UNDER_TEST = "Ethernet88"
         LAG_ADDR_UNDER_TEST = "11.11.11.1/28"
-        DIRECT_SUBNET_UNDER_TEST = "11.11.11.0/28"
 
         # Create mirror session
         self.create_mirror_session(session, src_ip, dst_ip, gre_type, dscp, ttl, queue)

--- a/tests/test_mirror_port_erspan.py
+++ b/tests/test_mirror_port_erspan.py
@@ -7,6 +7,11 @@ import pytest
 @pytest.mark.usefixtures('dvs_mirror_manager')
 
 class TestMirror(object):
+    def set_lag_oper_status(self, dvs, lag_name, status):
+        dvs.runcmd("bash -c 'echo " + ("1" if status == "up" else "0") + \
+                " > /sys/class/net/" + lag_name + "/carrier'")
+        time.sleep(1)
+
     def test_PortMirrorERSpanAddRemove(self, dvs, testlog):
         """
         This test covers the basic ERSPANmirror session creation and removal operations
@@ -244,6 +249,7 @@ class TestMirror(object):
 
         # bring up port channel and port channel member
         dvs.set_interface_status("PortChannel008", "up")
+        self.set_lag_oper_status(dvs, "PortChannel008", "up")
         dvs.set_interface_status("Ethernet88", "up")
 
         # add ip address to port channel 008
@@ -535,6 +541,7 @@ class TestMirror(object):
 
         # bring up port channel and port channel member
         dvs.set_interface_status("PortChannel008", "up")
+        self.set_lag_oper_status(dvs, "PortChannel008", "up")
         dvs.set_interface_status("Ethernet88", "up")
 
         # add ip address to port channel 008

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -862,15 +862,15 @@ class TestSubPortIntf(object):
         # Clean up
         rif_cnt = len(self.asic_db.get_keys(ASIC_RIF_TABLE))
 
+        # Remove ecmp route entry
+        self.remove_route_appl_db(ip_prefix)
+
         # Remove sub port interfaces
         self.remove_nhg_router_intfs(dvs, parent_port_prefix, parent_port_idx_base, int(vlan_id), nhop_num)
 
         # Remove router interfaces on parent ports
         if create_intf_on_parent_port == True:
             self.remove_nhg_router_intfs(dvs, parent_port_prefix, parent_port_idx_base, 0, nhop_num)
-
-        # Remove ecmp route entry
-        self.remove_route_appl_db(ip_prefix)
 
         # Removal of router interfaces indicates the proper removal of nhg, nhg members, next hop objects, and neighbor entries
         self.asic_db.wait_for_n_keys(ASIC_RIF_TABLE, rif_cnt - nhop_num if create_intf_on_parent_port == False else rif_cnt - nhop_num * 2)
@@ -1038,15 +1038,15 @@ class TestSubPortIntf(object):
             self.add_lag_members(parent_port, [phy_port])
             self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, 1)
         self.create_sub_port_intf_profile(sub_port_intf_name)
-        time.sleep(1)
+        time.sleep(2)
         self.dvs_mirror.verify_session_status(session_name, INACTIVE)
 
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
-        time.sleep(1)
+        time.sleep(2)
         self.dvs_mirror.verify_session_status(session_name, INACTIVE)
 
         self.add_neigh_appl_db(sub_port_intf_name, self.IPV4_NEXT_HOP_UNDER_TEST, dst_mac)
-        time.sleep(1)
+        time.sleep(2)
         self.dvs_mirror.verify_session_status(session_name, INACTIVE)
 
         ip_prefix = "2.2.2.0/24"
@@ -1177,11 +1177,11 @@ class TestSubPortIntf(object):
             self.add_lag_members(parent_port, [phy_port])
             self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, 1)
         self.create_sub_port_intf_profile(sub_port_intf_name)
-        time.sleep(1)
+        time.sleep(2)
         self.dvs_mirror.verify_session_status(session_name, INACTIVE)
 
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
-        time.sleep(1)
+        time.sleep(2)
         self.dvs_mirror.verify_session_status(session_name, INACTIVE)
 
         self.add_neigh_appl_db(sub_port_intf_name, self.IPV4_NEXT_HOP_UNDER_TEST, dst_mac)
@@ -1231,6 +1231,10 @@ class TestSubPortIntf(object):
             # Oper up lag
             self.set_parent_port_oper_status(dvs, parent_port, UP)
         self.dvs_mirror.verify_session(dvs, session_name, fv_dict_asic_db, fv_dict_state_db)
+
+        # Remove mirror session
+        self.dvs_mirror.remove_mirror_session(session_name)
+        self.dvs_mirror.verify_no_mirror()
 
         # Clean up
         self.remove_neigh_appl_db(sub_port_intf_name, self.IPV4_NEXT_HOP_UNDER_TEST)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -130,6 +130,12 @@ class TestSubPortIntf(object):
         tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
         tbl.set(sub_port_intf_name + APPL_DB_SEPARATOR + ip_addr, fvs)
 
+    def add_route_appl_db(self, ip_prefix, nhop_ips, ifnames):
+        fvs = swsscommon.FieldValuePairs([("nexthop", ",".join(nhop_ips)), ("ifname", ",".join(ifnames))])
+
+        tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_ROUTE_TABLE_NAME)
+        tbl.set(ip_prefix, fvs)
+
     def set_sub_port_intf_admin_status(self, sub_port_intf_name, status):
         fvs = {ADMIN_STATUS: status}
 
@@ -161,6 +167,10 @@ class TestSubPortIntf(object):
     def remove_sub_port_intf_ip_addr_appl_db(self, sub_port_intf_name, ip_addr):
         tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_INTF_TABLE_NAME)
         tbl._del(sub_port_intf_name + APPL_DB_SEPARATOR + ip_addr)
+
+    def remove_route_appl_db(self, ip_prefix):
+        tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_ROUTE_TABLE_NAME)
+        tbl._del(ip_prefix)
 
     def get_oids(self, table):
         return self.asic_db.get_keys(table)
@@ -781,10 +791,8 @@ class TestSubPortIntf(object):
         self.asic_db.wait_for_n_keys(ASIC_NEXT_HOP_TABLE, nhop_cnt + nhop_num if create_intf_on_parent_port == False else nhop_cnt + nhop_num * 2)
 
         # Create multi-next-hop route entry
-        rt_tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_ROUTE_TABLE_NAME)
-        fvs = swsscommon.FieldValuePairs([("nexthop", ",".join(nhop_ips)), ("ifname", ",".join(ifnames))])
         ip_prefix = "2.2.2.0/24"
-        rt_tbl.set(ip_prefix, fvs)
+        self.add_route_appl_db(ip_prefix, nhop_ips, ifnames)
 
         # Verify route entry created in ASIC_DB and get next hop group oid
         nhg_oid = self.get_ip_prefix_nhg_oid(ip_prefix)
@@ -822,7 +830,7 @@ class TestSubPortIntf(object):
             self.remove_nhg_router_intfs(dvs, parent_port_prefix, parent_port_idx_base, 0, nhop_num)
 
         # Remove ecmp route entry
-        rt_tbl._del(ip_prefix)
+        self.remove_route_appl_db(ip_prefix)
 
         # Removal of router interfaces indicates the proper removal of nhg, nhg members, next hop objects, and neighbor entries
         self.asic_db.wait_for_n_keys(ASIC_RIF_TABLE, rif_cnt - nhop_num if create_intf_on_parent_port == False else rif_cnt - nhop_num * 2)
@@ -898,10 +906,8 @@ class TestSubPortIntf(object):
             self.asic_db.wait_for_n_keys(ASIC_NEXT_HOP_TABLE, nhop_cnt + nhop_num if create_intf_on_parent_port == False else nhop_cnt + nhop_num * 2)
 
             # Mimic pending multi-next-hop route entry task
-            rt_tbl = swsscommon.ProducerStateTable(self.app_db.db_connection, APP_ROUTE_TABLE_NAME)
-            fvs = swsscommon.FieldValuePairs([("nexthop", ",".join(nhop_ips)), ("ifname", ",".join(ifnames))])
             ip_prefix = "2.2.2.0/24"
-            rt_tbl.set(ip_prefix, fvs)
+            self.add_route_appl_db(ip_prefix, nhop_ips, ifnames)
 
             # Verify route entry created in ASIC_DB and get next hop group oid
             nhg_oid = self.get_ip_prefix_nhg_oid(ip_prefix)
@@ -927,7 +933,7 @@ class TestSubPortIntf(object):
             if create_intf_on_parent_port == True:
                 self.remove_nhg_next_hop_objs(dvs, parent_port_prefix, parent_port_idx_base, 0, nhop_num)
             # Remove ecmp route entry
-            rt_tbl._del(ip_prefix)
+            self.remove_route_appl_db(ip_prefix)
             # Removal of next hop objects indicates the proper removal of route entry, nhg, and nhg members
             self.asic_db.wait_for_n_keys(ASIC_NEXT_HOP_TABLE, nhop_cnt - nhop_num if create_intf_on_parent_port == False else nhop_cnt - nhop_num * 2)
 

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -34,6 +34,7 @@ ASIC_LAG_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_LAG"
 
 ADMIN_STATUS = "admin_status"
 UP = "up"
+DOWN = "down"
 
 ETHERNET_PREFIX = "Ethernet"
 LAG_PREFIX = "PortChannel"
@@ -1215,7 +1216,7 @@ class TestSubPortIntf(object):
             self.remove_route_appl_db(self.IPV4_SUBNET_UNDER_TEST)
         else:
             # Oper down lag
-            self.set_parent_port_oper_status(dvs, parent_port, "down")
+            self.set_parent_port_oper_status(dvs, parent_port, DOWN)
         self.dvs_mirror.verify_session_status(session_name, INACTIVE)
         self.asic_db.wait_for_n_keys(ASIC_MIRROR_SESSION_TABLE, 0)
 
@@ -1224,7 +1225,7 @@ class TestSubPortIntf(object):
             self.add_route_appl_db(self.IPV4_SUBNET_UNDER_TEST, ["0.0.0.0"], [sub_port_intf_name])
         else:
             # Oper up lag
-            self.set_parent_port_oper_status(dvs, parent_port, "up")
+            self.set_parent_port_oper_status(dvs, parent_port, UP)
         self.dvs_mirror.verify_session(dvs, session_name, fv_dict_asic_db, fv_dict_state_db)
 
         # Clean up


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Deal with the possibility that the chosen next hop object goes through a local sub port router interface


**Why I did it**
Mirror destination lookup is done in default VRF. As a sub port router interface can be the local router interface of the next hop or a next hop group member of an ip prefix in default VRF, here we deal with such a likelihood.


**How I verified it**
Newly added vs tests:

- Mirror session add removal, together with the following update event MirrorOrch observes:
    - ip prefix removal and add
    - neighbor mac update
    - lag member removal and add
- Mirror session status update at parent port oper status change for the case of mirror destination in directly connected subnet ()
- Next hop group update on LPM ip prefix that causes monitor port (Mirror to port) to migrate from via a local sub port router interface to via other local RIFs, and vice versa. Validate a local RIF migrated to/back from being one of the following types:
    - EthernetX
    - PortChannelX
    - Vlan interface of the same vlan id
    - Vlan interface of a different vlan id
    - EthernetX.Y sub port interface
    - PortChannelX.Y sub port interface
- LPM ip prefix update that cause monitor port (Mirror to port) to migrate from via a local sub port router interface to via other local RIFs, and vice versa. Validate a local RIF migrated to/back from being one of the following types listed above.


**Details if related**

